### PR TITLE
fix: Add missing cryptography dependency (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-12-26
+
+### Fixed
+- **Added missing `cryptography` dependency to setup.py** (#30)
+  - Package was importing from `cryptography` but not declaring it as a dependency
+  - Caused `ModuleNotFoundError` when installed in fresh environments
+  - Added `cryptography>=41.0.0` to `install_requires`
+  - Required for PEM export/import (`to_pem()`, `from_pem()`) and keystore encryption
+  - **CRITICAL**: This is a patch release to fix broken installations
+
 ## [0.2.0] - 2025-12-26
 
 ### Changed

--- a/didlite/__init__.py
+++ b/didlite/__init__.py
@@ -16,7 +16,7 @@
 didlite: Lightweight Identity for Agents & IoT
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "Jon DePalma"
 
 # Expose the main classes to the top level

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,13 @@ from setuptools import setup, find_packages
 
 setup(
     name="didlite",
-    version="0.1.5",
+    version="0.2.1",
     description="Lightweight, web-only DID:KEY (Ed25519) implementation for Agents",
     packages=find_packages(),
     install_requires=[
         "pynacl>=1.5.0",
         "py-multibase>=1.0.0",
+        "cryptography>=41.0.0",  # Required for PEM export/import and keystore encryption
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
## Summary
Critical bug fix for missing `cryptography` dependency that was causing `ModuleNotFoundError` when installing didlite in fresh environments.

## Changes
- ✅ Added `cryptography>=41.0.0` to `install_requires` in setup.py
- ✅ Bumped version to v0.2.1 (patch release)
- ✅ Updated CHANGELOG.md with fix details

## Root Cause
The package imports from `cryptography` in two modules:
- `didlite/core.py:20-22` - for PEM export/import (`to_pem()`, `from_pem()`)
- `didlite/keystore.py:22-24` - for Fernet encryption in encrypted keystores

However, `cryptography` was not declared in the `install_requires` list, causing installation to succeed but imports to fail.

## Test Results
✅ **All tests passed: 166 passed, 2 skipped in 9.66s**

### Verification Steps
1. Deleted existing venv
2. Created fresh virtual environment
3. Installed with `pip install -e .`
4. Verified `cryptography-46.0.3` was installed automatically
5. Confirmed import works: `import didlite; agent = didlite.AgentIdentity()`
6. Full test suite executed successfully

## Impact
- **Severity**: CRITICAL - blocks basic usage of the package
- **Affected versions**: v0.2.0 and earlier (all versions with PEM/keystore features)
- **Fix type**: Patch release (v0.2.1)

## Release Notes
This is a **patch release** fixing a critical dependency issue. Users upgrading from v0.2.0 will automatically get the missing dependency installed.

Resolves #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)