### PR TITLE
chore: Bump version to v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-01-09
+
 ### Added
 - **GitHub CODEOWNERS file** for automated review requests
   - Defines code ownership for security-critical components

--- a/didlite/__init__.py
+++ b/didlite/__init__.py
@@ -16,7 +16,7 @@
 didlite: Lightweight Identity for Agents & IoT
 """
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 __author__ = "Jon DePalma"
 
 # Expose the main classes to the top level

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "didlite"
-version = "0.2.4"
+version = "0.2.5"
 description = "Zero-dependency-bloat Python library for W3C Decentralized Identifiers (DIDs) using Ed25519 keys"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Automated version bump for v0.2.5 release.

Repository governance, OWASP compliance testing, and PyO3 fixes

This PR updates:
- `pyproject.toml` - version field
- `didlite/__init__.py` - __version__ variable
- `CHANGELOG.md` - date stamp for v0.2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)